### PR TITLE
Updates Author information

### DIFF
--- a/.jazzy.yaml
+++ b/.jazzy.yaml
@@ -1,9 +1,9 @@
 module: DMSSDK
-author: 3 SIDED CUBE
-author_url: https://3sidedcube.com/
-github_url: https://github.com/3sidedcube/dmssdk-ios-framework
-github-file-prefix: https://github.com/3sidedcube/dmssdk-ios-framework/tree/master
+author: American Red Cross
+author_url: https://americanredcross.com/
+github_url: https://github.com/americanredcross/dmssdk-ios-framework
+github-file-prefix: https://github.com/americanredcross/dmssdk-ios-framework/tree/master
 clean: true
 exclude: [DMSSDK/Utilities.swift]
-copyright: '© 2017 [3 SIDED CUBE](https://3sidedcube.com).'
+copyright: '© 2017 [American Red Cross](https://americanredcross.com).'
 readme: README.md

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The DMS SDK provides models and classes to work with the ARC DMS system.
 6. Ensure that `DMSSDK.framework` and `ThunderRequest.framework` are listed under the `Target Dependencies` section of your `Build Phases`
 
 ## Code Documentation
-The documentation for the project is available [here](https://3sidedcube.github.io/dmssdk-ios-framework/)
+The documentation for the project is available [here](https://americanredcross.github.io/dmssdk-ios-framework/)
 
 ## Usage
 
@@ -25,7 +25,7 @@ Responsible for downloading bundles from your DMS. This controller will use the 
 
 ### DirectoryManager.swift
 
-By default this manager will look for a structure.json in the `CIEBundle` repository. You can also manually initialise this controller with your own JSON data. 
+By default this manager will look for a structure.json in the `CIEBundle` repository. You can also manually initialise this controller with your own JSON data.
 
 The manager is responsible for converting the JSON into `Directory` objects which can then be used to display DMS content however you wish.
 


### PR DESCRIPTION
The URLs for Jazzy documentation have been updated to reflect the new host of American Red Cross.

The readme has also had one URL updated to point to the new hosted documentation under the American Red Cross account.